### PR TITLE
fixed divide by zero and removed line_items from cart response

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -61,8 +61,10 @@ class Product(SafeDeleteModel):
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
-
-        avg = total_rating / len(ratings)
+        try:
+            avg = total_rating / len(ratings)
+        except ZeroDivisionError:
+            avg = 0
         return avg
 
     class Meta:

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -64,7 +64,7 @@ class Product(SafeDeleteModel):
         try:
             avg = total_rating / len(ratings)
         except ZeroDivisionError:
-            avg = 0
+            avg = total_rating
         return avg
 
     class Meta:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -156,7 +156,6 @@ class Profile(ViewSet):
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
-                # cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -156,7 +156,7 @@ class Profile(ViewSet):
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                # cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
 


### PR DESCRIPTION

## Changes

- Commented out line that returns the extra "line_items" on the cart
- Added a try/except to handle the rating 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET profile/cart produces 

**Response**

HTTP/1.1 200 OK

```json
{ 
"lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "900",
                "price": 1296.98,
                "number_sold": 0,
                "description": "1987 Saab",
                "quantity": 2,
                "created_date": "2019-03-19",
                "location": "Vratsa",
                "image_path": null,
                "average_rating": 0
            }
        },
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Get request on /profile/cart

## Related Issues

- Fixes #2
- Fixes #11