### PR TITLE
Gm user payment types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer_id = Customer.objects.get(user=request.auth.user)
 
         if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            payment_types = payment_types.filter(customer__id=customer_id.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -80,8 +80,11 @@ class Payments(ViewSet):
     def list(self, request):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
-
-        customer_id = Customer.objects.get(user=request.auth.user)
+        
+        try:
+            customer_id = Customer.objects.get(user=request.auth.user)
+        except AttributeError:
+            customer_id = None
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id.id)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -82,12 +82,12 @@ class Payments(ViewSet):
         payment_types = Payment.objects.all()
         
         try:
-            customer_id = Customer.objects.get(user=request.auth.user)
+            customer = Customer.objects.get(user=request.auth.user)
         except AttributeError:
-            customer_id = None
+            customer = None
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id.id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

Added customer authorization to the paymenttypes list function so you only get the payment methods related to that user.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET from /paymenttypes from an authenticated user provides response of user's payment types.


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 4,
        "url": "http://localhost:8000/paymenttypes/4",
        "merchant_name": "Amex",
        "account_number": "000000000000",
        "expiration_date": "2023-12-12",
        "create_date": "2020-12-12"
    }
]
```

## Testing

Description of how to test code...

GET /paymenttypes with authenticated user

## Related Issues
#8 
