### PR TITLE
can get products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -248,6 +248,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -271,6 +272,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

added query of location to the products endpoint.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?location=location` returns products where the location contains the provided query paramaters
**Example**
http://localhost:8000/products?location=ngu

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] GET `/products?location=location`


## Related Issues

- fixes #12 