### PR TITLE
added query param for min_price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,6 +249,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         location = self.request.query_params.get('location', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -272,6 +273,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            def price_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+
+            products = filter(price_filter, products)
 
         if location is not None:
             products = products.filter(location__contains=location)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added min_price query string to /products that returns products with a price greater than or equal to the paramater
- 
## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?min_price=1900` 


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 20,
        "name": "Mazda6",
        "price": 1900.67,
        "number_sold": 0,
        "description": "2005 Mazda",
        "quantity": 2,
        "created_date": "2018-12-13",
        "location": "Tuburan",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 32,
        "name": "DB9",
        "price": 1912.51,
        "number_sold": 0,
        "description": "2008 Aston Martin",
        "quantity": 3,
        "created_date": "2019-01-06",
        "location": "Paris 07",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 41,
        "name": "Impreza",
        "price": 1913.81,
        "number_sold": 0,
        "description": "1998 Subaru",
        "quantity": 4,
        "created_date": "2019-03-15",
        "location": "Dingjiaqiao",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 60,
        "name": "Elantra",
        "price": 1989.84,
        "number_sold": 0,
        "description": "1994 Hyundai",
        "quantity": 1,
        "created_date": "2019-01-19",
        "location": "Sosnovoborsk",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] GET `/products?min_price={number}` 


## Related Issues

- Fixes #9 