### PR TITLE
added test to verify items add to new order after order closed

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -99,3 +99,40 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["payment_type"], "http://testserver/paymenttypes/1")
         
     # TODO: New line item is not added to closed order
+    def test_new_line_new_order(self):
+
+        # add product to order
+        carturl = "/cart"
+        data = { "product_id": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(carturl, data, format='json')
+        
+        # close order
+        PaymentTests.test_create_payment_type(self)
+        url = "/orders/1"
+        paymentdata = { "payment_type": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, paymentdata, format='json')
+        
+        # assert length of cart items is 1
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response["lineitems"]), 1)
+        
+        # add product to hopefully second order
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(carturl, data, format='json')
+        
+        #assert length of original cart is still 1
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response["lineitems"]), 1)
+        
+        #assert length of second cart is 1
+        url2 = '/orders/2'
+        response = self.client.get(url2, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response["lineitems"]), 1)

--- a/tests/order.py
+++ b/tests/order.py
@@ -98,7 +98,6 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["payment_type"], "http://testserver/paymenttypes/1")
         
-    # TODO: New line item is not added to closed order
     def test_new_line_new_order(self):
 
         # add product to order


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added test to verify a new item goes to a new order after the first order is closed

## Testing

Description of how to test code...

- [ ] `./seed_data.sh` to migrate and seed database
- [ ] python manage.py test tests


## Related Issues

- fixes #16 