### PR TITLE
added rating products and test to verify average rating works

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -5,7 +5,7 @@ from safedelete.models import SOFT_DELETE
 from .customer import Customer
 from .productcategory import ProductCategory
 from .orderproduct import OrderProduct
-from .productrating import ProductRating
+from .rating import Rating
 
 
 class Product(SafeDeleteModel):
@@ -57,14 +57,14 @@ class Product(SafeDeleteModel):
         Returns:
             number -- The average rating for the product
         """
-        ratings = ProductRating.objects.filter(product=self)
+        ratings = Rating.objects.filter(product=self)
         total_rating = 0
         for rating in ratings:
-            total_rating += rating.rating
+            total_rating += rating.score
         try:
             avg = total_rating / len(ratings)
         except ZeroDivisionError:
-            avg = total_rating
+            avg = 0
         return avg
 
     class Meta:

--- a/bangazonapi/models/productrating.py
+++ b/bangazonapi/models/productrating.py
@@ -5,7 +5,7 @@ from .customer import Customer
 
 class ProductRating(models.Model):
 
-    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
+    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="deprecated_ratings")
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])
 

--- a/bangazonapi/models/rating.py
+++ b/bangazonapi/models/rating.py
@@ -1,15 +1,14 @@
 from django.db import models
 from django.core.validators import MaxValueValidator, MinValueValidator
 from .customer import Customer
-from .product import Product
+
 
 class Rating(models.Model):
 
-    customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
-    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)
+    customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
     score = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)],)
 
     class Meta:
         verbose_name = ("rating")
         verbose_name_plural = ("ratings")
-

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -166,7 +166,6 @@ class Products(ViewSet):
         try:
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
-            print(serializer.data)
             return Response(serializer.data)
         except Product.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/tests/product.py
+++ b/tests/product.py
@@ -113,8 +113,8 @@ class ProductTests(APITestCase):
         #create product
         self.test_create_product()
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        
         #verify average rating is 0
-
         url = "/products/1"
         response = self.client.get(url, None, form=json)
         json_response = response.json()

--- a/tests/product.py
+++ b/tests/product.py
@@ -108,3 +108,29 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # TODO: Product can be rated. Assert average rating exists.
+    def test_product_rated(self):
+        
+        #create product
+        self.test_create_product()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        #verify average rating is 0
+
+        url = "/products/1"
+        response = self.client.get(url, None, form=json)
+        json_response = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["average_rating"], 0)
+
+        url2 = "/products/1/rate"
+        data1 = {
+            "rating": 4
+        }
+        #rate product 
+        self.client.post(url2, data=data1, form=json)
+    
+        #get product
+        url2 = "/products/1"
+        response = self.client.get(url, None, form=json)
+        json_response = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["average_rating"], 4)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added functionality of adding a rating at `/products/{id}/rating`
- added test to test that avg rating exists

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

put  `/products/{id}/rating` with authed user and user's payment type

```json
{
    rating: 2
}
```

**Response**

HTTP/1.1 201 CREATED

```json
{
    "customer": {
        "id": 7,
        "phone_number": "555-1212",
        "address": "100 Indefatiguable Way",
        "user": 8
    },
    "product": {
        "id": 2,
        "deleted": null,
        "name": "Golf",
        "price": 653.59,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Zhongshan",
        "image_path": null,
        "customer": 4,
        "category": 2
    },
    "score": 2
}
```



## Testing

Description of how to test code...

- [ ] `./seed_data.sh` to migrate and seed database
- [ ] python manage.py test tests


## Related Issues

- fixes #19 